### PR TITLE
Allow using mdash instead of --

### DIFF
--- a/lib/lita/extensions/keyword_arguments/parser.rb
+++ b/lib/lita/extensions/keyword_arguments/parser.rb
@@ -8,7 +8,7 @@ module Lita
 
         def initialize(spec, args)
           @spec = spec
-          @args = args
+          @args = prepare_args(args)
         end
 
         def parse
@@ -30,6 +30,12 @@ module Lita
           opt_args << opt_options
 
           parser.on(*opt_args)
+        end
+
+        def prepare_args(args)
+          args.map do |arg|
+            arg.tr('—', '--')
+          end
         end
 
         def parser

--- a/spec/lita/extensions/keyword_arguments/parser_spec.rb
+++ b/spec/lita/extensions/keyword_arguments/parser_spec.rb
@@ -10,6 +10,15 @@ describe Lita::Extensions::KeywordArguments::Parser do
     expect(subject.parse).to eq(foo: "bar")
   end
 
+  it "parses mdash flags" do
+    subject = described_class.new(
+      { foo: {} },
+      "—foo bar".split
+    )
+
+    expect(subject.parse).to eq(foo: "bar")
+  end
+
   it "sets missing arguments to nil" do
     subject = described_class.new(
       { foo: {} },


### PR DESCRIPTION
Slack on OS X (or just OS X) automatically transforms -- into — which breaks the command line parser–it does not recognise the argument. This PR fixes this issue.
